### PR TITLE
Patch v2.1.2 — Multi Nodes Fix

### DIFF
--- a/src/candle_container.cpp
+++ b/src/candle_container.cpp
@@ -23,7 +23,7 @@ int main(int argc, char** argv)
     candleParams_S params = readParams(config_node);
     auto           candle = createCandle(params);
 
-    rclcpp::executors::MultiThreadedExecutor exec;
+    rclcpp::executors::SingleThreadedExecutor exec;
     exec.add_node(config_node);
 
     rclcpp::Node::SharedPtr md_node;

--- a/src/md_node.cpp
+++ b/src/md_node.cpp
@@ -3,7 +3,7 @@
 MdNode::MdNode(const rclcpp::NodeOptions&   options,
                std::shared_ptr<mab::Candle> candle,
                const candleParams_S&        params)
-    : Node("candle_md_node", options), m_candle(std::move(candle))
+    : Node("candle_md_node", options), m_candle(candle)
 {
     rclcpp::QoS defaultQoS(10);
     defaultQoS.reliable();

--- a/src/pds_modules/brake_resistor_ros.cpp
+++ b/src/pds_modules/brake_resistor_ros.cpp
@@ -26,7 +26,8 @@ bool BrakeResistorRos::setup(std::shared_ptr<rclcpp::Node> node,
     srvDisable = m_parentNode->create_service<candle_ros2::srv::GenericPds>(
         nodePrefix + "id_" + std::to_string(pdsId) + "/disable_" + std::string(MODULE_NAME) + "_" +
             std::to_string(static_cast<int>(socket)),
-        std::bind(&BrakeResistorRos::cbEnable, this, std::placeholders::_1, std::placeholders::_2));
+        std::bind(
+            &BrakeResistorRos::cbDisable, this, std::placeholders::_1, std::placeholders::_2));
 
     tmrPub = m_parentNode->create_wall_timer(std::chrono::milliseconds(timerMs),
                                              std::bind(&BrakeResistorRos::publishStatus, this));

--- a/src/pds_modules/isolated_converter_ros.cpp
+++ b/src/pds_modules/isolated_converter_ros.cpp
@@ -28,7 +28,7 @@ bool IsolatedConverterRos::setup(std::shared_ptr<rclcpp::Node> node,
         nodePrefix + "id_" + std::to_string(pdsId) + "/disable_" + std::string(MODULE_NAME) + "_" +
             std::to_string(static_cast<int>(socket)),
         std::bind(
-            &IsolatedConverterRos::cbEnable, this, std::placeholders::_1, std::placeholders::_2));
+            &IsolatedConverterRos::cbDisable, this, std::placeholders::_1, std::placeholders::_2));
 
     tmrPub = m_parentNode->create_wall_timer(std::chrono::milliseconds(timerMs),
                                              std::bind(&IsolatedConverterRos::publishStatus, this));

--- a/src/pds_modules/power_stage_ros.cpp
+++ b/src/pds_modules/power_stage_ros.cpp
@@ -27,7 +27,7 @@ bool PowerStageRos::setup(std::shared_ptr<rclcpp::Node> node,
     srvDisable = m_parentNode->create_service<candle_ros2::srv::GenericPds>(
         nodePrefix + "id_" + std::to_string(pdsId) + "/disable_" + std::string(MODULE_NAME) + "_" +
             std::to_string(static_cast<int>(socket)),
-        std::bind(&PowerStageRos::cbEnable, this, std::placeholders::_1, std::placeholders::_2));
+        std::bind(&PowerStageRos::cbDisable, this, std::placeholders::_1, std::placeholders::_2));
 
     tmrPub = m_parentNode->create_wall_timer(std::chrono::milliseconds(timerMs),
                                              std::bind(&PowerStageRos::publishStatus, this));

--- a/src/pds_node.cpp
+++ b/src/pds_node.cpp
@@ -3,7 +3,7 @@
 PdsNode::PdsNode(const rclcpp::NodeOptions&   options,
                  std::shared_ptr<mab::Candle> candle,
                  const candleParams_S&        params)
-    : Node("candle_pds_node", options), m_candle(std::move(candle)), m_defaultQoS(10)
+    : Node("candle_pds_node", options), m_candle(candle), m_defaultQoS(10)
 {
     m_defaultQoS.reliable();
 


### PR DESCRIPTION
## Features:
- Remove `MultiThreadedExecutor` due to the PDS software multithreading limitations.
- Fix PDS modules' disable callbacks.